### PR TITLE
Update CODEOWNERS to avoid non-existent team references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default code owner for all files.
+# TODO: Replace @REPOSITORY_OWNER with the actual repository owner account.
+#       Once a maintainers team exists, this can be updated to that team (e.g. @org/maintainers).
+* @REPOSITORY_OWNER


### PR DESCRIPTION
### Motivation
- Ensure the repository does not reference GitHub teams that may not exist by using the repository owner as the default CODEOWNERS entry and documenting how to switch to a maintainers team later.

### Description
- Add `.github/CODEOWNERS` with a catch-all entry `* @REPOSITORY_OWNER` and a clear TODO comment explaining how to replace the placeholder with the actual repository owner or a maintainers team when one exists.

### Testing
- Ran `git status --short` to confirm the working tree is clean and inspected the new file with `nl -ba .github/CODEOWNERS`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce6b02e79c8333871da8ca2e1c2c57)