### PR TITLE
Migrate to Jekyll _labs/ collection for auto-generated directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,18 +11,21 @@ v1 scope is intentionally constrained: a curated directory of OA biomechanics la
 ## Architecture
 
 ```
-index.md                         # Site entry point
+index.md                          # Site entry point
+_config.yml                       # Jekyll configuration (defines labs collection)
+_labs/
+  <descriptive-kebab-case>.md     # One file per lab/group/center entry (Jekyll collection)
 labs/
-  index.md                       # Directory section landing page
-  <descriptive-kebab-case>.md    # One file per lab/group/center entry
+  index.md                        # Auto-generated directory listing (Liquid template)
 templates/
-  lab-entry-template.md          # Canonical schema for new entries
+  lab-entry-template.md           # Canonical schema for new entries (includes YAML front matter)
 .github/
   PULL_REQUEST_TEMPLATE.md
   CODEOWNERS
+  ISSUE_TEMPLATE/                 # Structured contribution forms (Issues #4 and #5)
 ```
 
-Each `labs/*.md` file is a self-contained entry. The `labs/index.md` must be kept in sync whenever entries are added or removed.
+Entries live in `_labs/` as a Jekyll collection. Each entry has YAML front matter at the top (title, entry_type, lead_investigators, institution, city, country, visitor_exchange_openness, focus_areas) followed by the full Markdown content. `labs/index.md` auto-generates the listing via Liquid — do not edit it manually to add entries.
 
 ## Content model
 
@@ -34,7 +37,7 @@ The canonical field structure lives in `templates/lab-entry-template.md`. Always
 
 ## Conventions
 
-- New entry filenames: `labs/<descriptive-kebab-case>.md`
+- New entry filenames: `_labs/<descriptive-kebab-case>.md`
 - Internal repo links: relative paths. External links: full URLs.
 - Descriptions: concise, plain language — not promotional.
 - When editing an entry: touch only that entry and `labs/index.md` if needed. Do not reformat unrelated content.
@@ -108,4 +111,4 @@ Before proposing changes, manually confirm:
 - Markdown headings are coherent and render correctly.
 - Internal links resolve to existing files.
 - New entry filenames follow kebab-case convention.
-- `labs/index.md` reflects any added/removed entries (until Jekyll auto-directory is implemented).
+- `labs/index.md` is auto-generated — do not manually add entry links to it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,15 @@ In v1, the main contribution type is a **new or updated lab/group/center entry**
 
 ## Quick start (recommended)
 
+**New to GitHub?** Use the [new lab entry form](https://github.com/oarsi-biomech/resource-hub/issues/new?template=new-lab-entry.yml) — no markdown editing required.
+
+**Comfortable with GitHub?**
+
 1. Open `templates/lab-entry-template.md`.
-2. Copy it into a new file in `labs/` (for example: `labs/example-lab-name.md`).
-3. Fill required fields.
-4. Remove any optional sections that are empty.
-5. Add your new entry link to `labs/index.md`.
+2. Copy it into a new file in `_labs/` (for example: `_labs/example-lab-name.md`).
+3. Fill required fields. Add the YAML front matter block at the top (see template).
+4. Optional sections can be left with placeholder text — maintainers will clean up as needed.
+5. The directory listing updates automatically — no need to edit `labs/index.md`.
 6. Open a pull request using the repository PR template.
 
 ## Entry quality checklist

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ This is a growing, community-contributed resource — new labs are added regular
 ```text
 .
 ├── index.md
+├── _labs/
+│   └── *.md          # lab/group/center entries (Jekyll collection)
 ├── labs/
-│   ├── index.md
-│   └── *.md
+│   └── index.md      # auto-generated directory listing
+├── _config.yml       # Jekyll configuration
 ├── templates/
 │   └── lab-entry-template.md
 ├── CONTRIBUTING.md

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,7 @@
+title: OARSI Biomechanics Resource Hub
+description: A community-driven directory for osteoarthritis biomechanics labs, groups, and centers.
+
+collections:
+  labs:
+    output: true
+    permalink: /labs/:name/

--- a/_labs/ai-biomechanics-lab.md
+++ b/_labs/ai-biomechanics-lab.md
@@ -1,3 +1,21 @@
+---
+title: AI Biomechanics Lab
+entry_type: lab
+lead_investigators: Dr. Kerry E. Costello
+institution: University of Florida
+city: Gainesville, FL
+country: USA
+visitor_exchange_openness: maybe
+focus_areas:
+  - Knee OA
+  - Hip OA
+  - Gait biomechanics
+  - Wearable sensors
+  - Machine learning
+  - Longitudinal movement analysis
+  - Movement variability
+---
+
 # AI Biomechanics Lab
 
 ## Entry metadata

--- a/labs/index.md
+++ b/labs/index.md
@@ -1,17 +1,20 @@
+---
+title: Labs / Groups / Centers Directory
+---
+
 # Labs / Groups / Centers Directory
 
-This directory contains entries for labs, groups, and centers working in osteoarthritis biomechanics and related areas.
+This directory lists labs, groups, and centers working in osteoarthritis biomechanics and related areas.
 
 ## Browse entries
 
-- Browse all entries in this folder:
-  https://github.com/oarsi-biomech/resource-hub/tree/main/labs
+{% assign sorted_labs = site.labs | sort: 'title' %}
+{% for lab in sorted_labs %}
+- [{{ lab.title }}]({{ lab.url }}) — {{ lab.institution }}, {{ lab.country }} *(Visitors: {{ lab.visitor_exchange_openness }})*
+{% endfor %}
 
 ## Add a new entry
 
-Use the template:
-- templates/lab-entry-template.md
+Use the [new lab entry form](https://github.com/oarsi-biomech/resource-hub/issues/new?template=new-lab-entry.yml) to submit your lab, group, or center.
 
-Then submit a pull request.
-
-See CONTRIBUTING.md for details.
+Comfortable with GitHub? You can also fork the repo, add a file to `_labs/`, and open a pull request. See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

--- a/templates/lab-entry-template.md
+++ b/templates/lab-entry-template.md
@@ -1,3 +1,16 @@
+---
+title: [Entry Name]
+entry_type: [lab | group | center]
+lead_investigators: [Lead investigator(s) / director(s)]
+institution: [Institution]
+city: [City]
+country: [Country]
+visitor_exchange_openness: [yes | maybe | no]
+focus_areas:
+  - [Focus area 1]
+  - [Focus area 2]
+---
+
 # [Entry Name]
 
 > Fill in all required fields.


### PR DESCRIPTION
## Summary

Implements #3. Migrates the site from a manually-maintained flat `labs/` folder to a Jekyll collection that auto-generates the directory listing.

## What changed

- Added `_config.yml` defining the `labs` Jekyll collection (permalinks to `/labs/:name/`)
- Moved `labs/ai-biomechanics-lab.md` → `_labs/ai-biomechanics-lab.md` with YAML front matter (title, entry_type, lead_investigators, institution, city, country, visitor_exchange_openness, focus_areas)
- Rewrote `labs/index.md` as a Liquid template — entries now appear automatically, alphabetically sorted, with institution, country, and visitor openness shown inline
- Updated `CONTRIBUTING.md` to reference `_labs/` path and link to the upcoming issue form
- Updated `README.md` repository structure diagram
- Updated `templates/lab-entry-template.md` to include the YAML front matter block contributors need to fill in
- Updated `CLAUDE.md` architecture section

## Why

The old `labs/index.md` required a manual edit every time a new entry was added, which would drift out of sync as the directory grows.

## v1 scope check

- [x] This PR is focused on the v1 directory scope.
- [x] This PR does not add dataset hosting, code hosting, maps, or advanced search/filtering features.

## Entry checklist

- [x] Required fields are completed.
- [x] Entry is linked from `labs/index.md` (via auto-generation).
- [x] Links and contact details were reviewed.

## Notes for reviewers

After merging, verify that GitHub Pages rebuilds correctly and the labs directory page shows the AI Biomechanics Lab entry. The YAML front matter fields locked here are the same fields Issues #4, #5, and #7 will rely on.