### PR TITLE
Add GitHub Issue Forms for new and update lab entries

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-lab-entry.yml
+++ b/.github/ISSUE_TEMPLATE/new-lab-entry.yml
@@ -1,0 +1,165 @@
+name: New Lab / Group / Center Entry
+description: Submit a new lab, group, or center to the directory. No GitHub experience needed — just fill out the form.
+title: "[New Entry]: "
+labels: ["new-lab-entry"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing to the OARSI Biomechanics Resource Hub!
+
+        Fill in the required fields below. Optional fields can be left blank — a maintainer will review your submission and format it for the directory.
+
+        **Already in the directory?** Use the [Update Existing Entry](https://github.com/oarsi-biomech/resource-hub/issues/new?template=update-lab-entry.yml) form instead.
+
+  - type: checkboxes
+    id: dedup-check
+    attributes:
+      label: Before you submit
+      options:
+        - label: I have browsed the [directory](https://oarsi-biomech.github.io/resource-hub/labs/) and my lab/group/center is not already listed.
+          required: true
+
+  - type: input
+    id: lab-name
+    attributes:
+      label: Lab / Group / Center Name
+      placeholder: e.g., AI Biomechanics Lab
+    validations:
+      required: true
+
+  - type: dropdown
+    id: entry-type
+    attributes:
+      label: Entry Type
+      options:
+        - lab
+        - group
+        - center
+    validations:
+      required: true
+
+  - type: input
+    id: lead-investigators
+    attributes:
+      label: Lead Investigator(s) / Director(s)
+      description: Full name(s) with title if applicable.
+      placeholder: e.g., Dr. Jane Smith
+    validations:
+      required: true
+
+  - type: input
+    id: institution
+    attributes:
+      label: Institution
+      placeholder: e.g., University of Florida
+    validations:
+      required: true
+
+  - type: input
+    id: city
+    attributes:
+      label: City
+      placeholder: e.g., Gainesville, FL
+    validations:
+      required: true
+
+  - type: input
+    id: country
+    attributes:
+      label: Country
+      placeholder: e.g., USA
+    validations:
+      required: true
+
+  - type: input
+    id: website
+    attributes:
+      label: Website or Profile Link
+      placeholder: https://
+    validations:
+      required: true
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Method
+      description: Email address, contact form URL, or other preferred contact.
+      placeholder: e.g., email@institution.edu
+    validations:
+      required: true
+
+  - type: dropdown
+    id: visitor-openness
+    attributes:
+      label: Openness to Visitors / Exchanges
+      description: Are you open to hosting OARSI scholarship awardees or other visitors/exchange researchers?
+      options:
+        - "yes"
+        - "maybe"
+        - "no"
+    validations:
+      required: true
+
+  - type: textarea
+    id: short-description
+    attributes:
+      label: Short Description
+      description: 2–5 sentences describing your group and its relevance to OA biomechanics or human movement research.
+    validations:
+      required: true
+
+  - type: textarea
+    id: focus-areas
+    attributes:
+      label: OA / Biomechanics Focus Areas
+      description: List your key research focus areas, one per line.
+      placeholder: |
+        Knee OA biomechanics
+        Gait analysis
+        Wearable sensors
+    validations:
+      required: true
+
+  - type: textarea
+    id: equipment-methods
+    attributes:
+      label: Equipment / Methods (Optional)
+      description: List major equipment or methods used in your lab, one per line.
+      placeholder: |
+        Instrumented gait analysis
+        Musculoskeletal modeling
+        Force plates
+
+  - type: textarea
+    id: github-links
+    attributes:
+      label: GitHub / Code Links (Optional)
+      description: Links to relevant GitHub repositories or code resources, one per line.
+      placeholder: https://github.com/your-lab
+
+  - type: textarea
+    id: datasets
+    attributes:
+      label: Open Datasets / Resources (Optional)
+      description: Links to any open datasets or shared resources, one per line.
+      placeholder: https://example.org/dataset
+
+  - type: textarea
+    id: affiliated-centers
+    attributes:
+      label: Affiliated Centers / Resources (Optional)
+      description: Names and links to affiliated centers or shared resources, one per line.
+      placeholder: Center for Example Research (https://example.org)
+
+  - type: textarea
+    id: visitor-notes
+    attributes:
+      label: Notes for Visitors / Trainees (Optional)
+      description: Any details about visitor logistics, exchange opportunities, or trainee expectations.
+
+  - type: textarea
+    id: collaboration-interests
+    attributes:
+      label: Additional Collaboration Interests (Optional)
+      description: Any other collaboration interests not covered above, one per line.

--- a/.github/ISSUE_TEMPLATE/update-lab-entry.yml
+++ b/.github/ISSUE_TEMPLATE/update-lab-entry.yml
@@ -1,0 +1,154 @@
+name: Update Existing Lab / Group / Center Entry
+description: Update information for a lab, group, or center already listed in the directory.
+title: "[Update Entry]: "
+labels: ["update-lab-entry"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to update your existing directory entry.
+
+        **Identify your entry** using the fields below, then fill in only the fields you want to change — leave everything else blank.
+
+        A maintainer will review your update and apply the changes.
+
+        **Not yet in the directory?** Use the [New Entry](https://github.com/oarsi-biomech/resource-hub/issues/new?template=new-lab-entry.yml) form instead.
+
+  - type: markdown
+    attributes:
+      value: "## Identify your entry"
+
+  - type: input
+    id: current-lab-name
+    attributes:
+      label: Current Lab / Group / Center Name
+      description: The name as it currently appears in the directory. Used to locate your entry.
+      placeholder: e.g., AI Biomechanics Lab
+    validations:
+      required: true
+
+  - type: input
+    id: current-lead-investigator
+    attributes:
+      label: Current Lead Investigator / Director Name
+      description: The lead investigator name as currently listed. Used alongside lab name to confirm the correct entry (some labs share similar names).
+      placeholder: e.g., Dr. Jane Smith
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## What would you like to change?
+
+        Fill in only the fields you want to update. Leave any field blank to keep the current value.
+
+  - type: input
+    id: new-lab-name
+    attributes:
+      label: New Lab / Group / Center Name (if changing)
+      placeholder: Leave blank to keep current name
+
+  - type: input
+    id: new-lead-investigators
+    attributes:
+      label: New Lead Investigator(s) / Director(s) (if changing)
+      placeholder: Leave blank to keep current value
+
+  - type: dropdown
+    id: entry-type
+    attributes:
+      label: Entry Type (if changing)
+      options:
+        - "— no change —"
+        - lab
+        - group
+        - center
+
+  - type: input
+    id: institution
+    attributes:
+      label: Institution (if changing)
+      placeholder: Leave blank to keep current value
+
+  - type: input
+    id: city
+    attributes:
+      label: City (if changing)
+      placeholder: Leave blank to keep current value
+
+  - type: input
+    id: country
+    attributes:
+      label: Country (if changing)
+      placeholder: Leave blank to keep current value
+
+  - type: input
+    id: website
+    attributes:
+      label: Website or Profile Link (if changing)
+      placeholder: Leave blank to keep current value
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Method (if changing)
+      placeholder: Leave blank to keep current value
+
+  - type: dropdown
+    id: visitor-openness
+    attributes:
+      label: Openness to Visitors / Exchanges (if changing)
+      options:
+        - "— no change —"
+        - "yes"
+        - "maybe"
+        - "no"
+
+  - type: textarea
+    id: short-description
+    attributes:
+      label: Short Description (if changing)
+      description: Leave blank to keep the current description.
+
+  - type: textarea
+    id: focus-areas
+    attributes:
+      label: OA / Biomechanics Focus Areas (if changing)
+      description: If updating, provide the full new list — one focus area per line.
+
+  - type: textarea
+    id: equipment-methods
+    attributes:
+      label: Equipment / Methods (if changing)
+      description: If updating, provide the full new list — one item per line.
+
+  - type: textarea
+    id: github-links
+    attributes:
+      label: GitHub / Code Links (if changing)
+      description: If updating, provide the full new list — one link per line.
+
+  - type: textarea
+    id: datasets
+    attributes:
+      label: Open Datasets / Resources (if changing)
+      description: If updating, provide the full new list — one link per line.
+
+  - type: textarea
+    id: affiliated-centers
+    attributes:
+      label: Affiliated Centers / Resources (if changing)
+      description: If updating, provide the full new list — one per line.
+
+  - type: textarea
+    id: visitor-notes
+    attributes:
+      label: Notes for Visitors / Trainees (if changing)
+      description: Leave blank to keep the current notes.
+
+  - type: textarea
+    id: collaboration-interests
+    attributes:
+      label: Additional Collaboration Interests (if changing)
+      description: If updating, provide the full new list — one per line.


### PR DESCRIPTION
## Summary

Implements #4 and #5. Adds two structured contribution forms that appear at the GitHub "New issue" page, allowing contributors to submit or update entries without editing markdown directly.

## What changed

**`.github/ISSUE_TEMPLATE/new-lab-entry.yml`**
- All required fields as labeled inputs (lab name, entry type, lead investigator, institution, city, country, website, contact, visitor openness, short description, focus areas)
- All optional fields as optional inputs (equipment/methods, GitHub links, datasets, affiliated centers, visitor notes, collaboration interests)
- Dedup checkbox: contributor must confirm they checked the directory first
- Auto-labels submissions `new-lab-entry` (needed for Issue #6 automation)
- Links to the update form for people who are already listed

**`.github/ISSUE_TEMPLATE/update-lab-entry.yml`**
- Identifies the entry using both lab name AND lead investigator name — two fields needed because many biomechanics labs share acronym-style names
- All fields are updatable including lab name and director (leadership and names change over time)
- Dropdowns include a '— no change —' option so contributors only fill in what's actually changing
- Auto-labels submissions `update-lab-entry`
- Links to the new entry form for people not yet listed

## v1 scope check

- [x] This PR is focused on the v1 directory scope.
- [x] This PR does not add dataset hosting, code hosting, maps, or advanced search/filtering features.

## Notes for reviewers

These forms go live as soon as the PR merges. Until Issue #6 (auto-PR Action) is implemented, submissions will create issues that maintainers handle manually. That's an acceptable interim state — the forms still guide contributors through required fields and prevent structural omissions.