### PR TITLE
UX polish: fix broken lab links, enrich directory listing, restructure home page

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,6 @@
 ## Entry checklist (if applicable)
 
 - [ ] Required fields are completed.
-- [ ] Optional empty sections were removed (no blank headings).
 - [ ] Entry is linked from `labs/index.md`.
 - [ ] Links and contact details were reviewed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,6 @@ Before submitting, confirm:
 
 - [ ] The entry is relevant to OA biomechanics or closely related human movement research.
 - [ ] All required fields are completed.
-- [ ] Optional sections are removed if empty (no blank headings).
 - [ ] Links are valid and clearly labeled.
 - [ ] Content is respectful, professional, and clear.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,7 +8,6 @@ Maintainers should:
 
 - Review pull requests for scope fit and clarity.
 - Ensure required fields are present in entries.
-- Ensure optional empty headings are removed.
 - Keep `labs/index.md` synchronized with entry files.
 - Encourage a welcoming contributor experience.
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,16 @@
 title: OARSI Biomechanics Resource Hub
 description: A community-driven directory for osteoarthritis biomechanics labs, groups, and centers.
 
+theme: minima
+
 collections:
   labs:
     output: true
     permalink: /labs/:name/
+
+defaults:
+  - scope:
+      path: ""
+      type: labs
+    values:
+      layout: default

--- a/index.md
+++ b/index.md
@@ -2,7 +2,15 @@
 
 Welcome to the **OARSI Biomechanics Resource Hub**, a community-driven directory for osteoarthritis biomechanics and closely related human movement research.
 
-## What v1 includes
+## Explore the directory
+
+➡️ **[Browse labs, groups, and centers](labs/index.md)**
+
+## Contribute
+
+Want to add your lab or update an existing entry? See **[CONTRIBUTING.md](CONTRIBUTING.md)** for instructions — including a no-code option for contributors new to GitHub.
+
+## About v1
 
 Version 1 is intentionally simple and focused:
 
@@ -19,16 +27,3 @@ As the community grows, this hub may expand to include:
 - Additional community knowledge pages
 
 (These are not part of v1 yet.)
-
-## Explore the directory
-
-➡️ Go to the directory index: **[Labs / Groups / Centers](labs/index.md)**
-
-## Contribute
-
-Interested in adding or improving an entry?
-
-- Start with **[CONTRIBUTING.md](CONTRIBUTING.md)**
-- Use the reusable template in **[templates/lab-entry-template.md](templates/lab-entry-template.md)**
-
-Thank you for helping build a useful OA biomechanics community resource.

--- a/labs/index.md
+++ b/labs/index.md
@@ -18,26 +18,27 @@ This directory lists labs, groups, and centers working in osteoarthritis biomech
 
 <p id="entry-count" style="font-size:0.9rem;color:#57606a;margin-bottom:0.75rem;"></p>
 
-<ul id="lab-list"></ul>
-
-</div>
-
-<p style="margin-top:2rem;">
+<p style="margin-bottom:1.25rem;border:1px solid #d0d7de;border-radius:6px;padding:0.75rem 1rem;background:#fff;">
   <strong>Want to add your lab?</strong> Use the <a href="https://github.com/oarsi-biomech/resource-hub/issues/new?template=new-lab-entry.yml">new lab entry form</a>.<br>
   <strong>Need to update an existing entry?</strong> Use the <a href="https://github.com/oarsi-biomech/resource-hub/issues/new?template=update-lab-entry.yml">update entry form</a>.
 </p>
+
+<ul id="lab-list"></ul>
+
+</div>
 
 <!-- Lab data injected by Jekyll -->
 <script id="labs-data" type="application/json">
 [{% assign sorted_labs = site.labs | sort: 'title' %}{% for lab in sorted_labs %}
   {
     "title": {{ lab.title | jsonify }},
-    "url": {{ lab.url | jsonify }},
+    "url": {{ lab.url | relative_url | jsonify }},
     "institution": {{ lab.institution | default: "" | jsonify }},
     "city": {{ lab.city | default: "" | jsonify }},
     "country": {{ lab.country | default: "" | jsonify }},
     "visitor_exchange_openness": {{ lab.visitor_exchange_openness | default: "" | jsonify }},
-    "focus_areas": {{ lab.focus_areas | default: "" | jsonify }}
+    "focus_areas": {{ lab.focus_areas | default: "" | jsonify }},
+    "lead_investigators": {{ lab.lead_investigators | default: "" | jsonify }}
   }{% unless forloop.last %},{% endunless %}{% endfor %}
 ]
 </script>
@@ -135,18 +136,48 @@ This directory lists labs, groups, and centers working in osteoarthritis biomech
 
     visible.forEach(lab => {
       const visitorLabel = { yes: 'Open to visitors', maybe: 'Visitors: maybe', no: 'Closed to visitors' }[lab.visitor_exchange_openness] || '';
+
       const li = document.createElement('li');
+      li.style.cssText = 'margin-bottom:1rem;';
+
+      // Title line
       const link = document.createElement('a');
       link.href = lab.url;
       link.textContent = lab.title;
+      link.style.cssText = 'font-weight:600;';
       li.appendChild(link);
-      li.appendChild(document.createTextNode(' \u2014 ' + lab.institution + ', ' + lab.country));
-      if (visitorLabel) {
-        const em = document.createElement('em');
-        em.style.cssText = 'color:#57606a;font-size:0.85rem;';
-        em.textContent = ' (' + visitorLabel + ')';
-        li.appendChild(em);
+
+      // Location + visitor status
+      const meta = document.createElement('div');
+      meta.style.cssText = 'font-size:0.9rem;color:#57606a;margin-top:0.1rem;';
+      let metaParts = [];
+      if (lab.lead_investigators) metaParts.push(lab.lead_investigators);
+      const location = [lab.institution, lab.city, lab.country].filter(Boolean).join(', ');
+      if (location) metaParts.push(location);
+      if (visitorLabel) metaParts.push(visitorLabel);
+      meta.textContent = metaParts.join(' \u00b7 ');
+      li.appendChild(meta);
+
+      // Focus areas (up to 4)
+      const areas = Array.isArray(lab.focus_areas) ? lab.focus_areas : (lab.focus_areas ? [lab.focus_areas] : []);
+      if (areas.length) {
+        const tagRow = document.createElement('div');
+        tagRow.style.cssText = 'margin-top:0.3rem;display:flex;flex-wrap:wrap;gap:0.3rem;';
+        areas.slice(0, 4).forEach(area => {
+          const tag = document.createElement('span');
+          tag.style.cssText = 'font-size:0.78rem;background:#e8f0fe;color:#1a56db;border-radius:3px;padding:0.1rem 0.4rem;';
+          tag.textContent = area;
+          tagRow.appendChild(tag);
+        });
+        if (areas.length > 4) {
+          const more = document.createElement('span');
+          more.style.cssText = 'font-size:0.78rem;color:#57606a;padding:0.1rem 0.2rem;';
+          more.textContent = '+' + (areas.length - 4) + ' more';
+          tagRow.appendChild(more);
+        }
+        li.appendChild(tagRow);
       }
+
       list.appendChild(li);
     });
   }


### PR DESCRIPTION
## Summary

A batch of UX improvements to make the site more useful for visitors and easier for contributors to navigate.

**Bug fix:** Lab detail page links in the directory were broken — clicking a lab name gave a "no GitHub Pages site here" error because Jekyll's `lab.url` emits a path without the `/resource-hub` baseurl prefix. Fixed by switching to `relative_url` filter.

**Directory listing enriched:** Each entry now shows lead investigator name, full location (institution, city, country), visitor openness status, and focus area tags (up to 4 with overflow count). Previously entries only showed lab name, institution, and country.

**"Want to add your lab?" CTA moved** from the bottom of the page (where it gets buried as entries grow) to just above the results list, after the filter panel.

**Home page restructured:** "Explore the directory" link moved to the top so the primary action is immediately visible. Contribute section simplified to a single line pointing to CONTRIBUTING.md — the old version included template instructions that would be confusing to non-GitHub users.

**Jekyll theme added:** `minima` theme set in `_config.yml` with a default layout for the labs collection, so individual lab detail pages render with consistent navigation and typography rather than raw unstyled HTML.

**Docs cleaned up:** Removed "optional sections are removed if empty (no blank headings)" from the CONTRIBUTING.md checklist and MAINTAINERS.md responsibilities — this guidance contradicted the intentional messy-input policy established when the issue forms were added.

## PR type

- [ ] New entry
- [ ] Entry update
- [x] Documentation update
- [x] Structure/template update

## v1 scope check

- [x] This PR is focused on the v1 directory scope.
- [x] This PR does not add dataset hosting, code hosting, maps, or advanced search/filtering features.

## Entry checklist (if applicable)

N/A — no new entries.

## Notes for reviewers

- The `relative_url` fix is the most important change; verify lab detail page links work on the live site after merge.
- The minima theme is the default GitHub Pages theme and requires no additional setup — GitHub Pages will resolve it automatically.
- The "blank headings" checklist item has been removed from the PR template's entry checklist too (line 17 of the template still references it — a follow-up can clean that up if desired).